### PR TITLE
feat(gpt): add budget tracking for chat interactions

### DIFF
--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -23,7 +23,7 @@ export async function handleBatchMessages(
 			text: v.message
 		}));
 
-		const gptResponse = await getYandexGPTResponse(gptMessages, 'base', businessConnectionId);
+		const gptResponse = await getYandexGPTResponse(gptMessages, 'base', businessConnectionId, chatId);
 		if (gptResponse?.text) {
 			const { bot } = await import('./bot-instance');
 			const { imitateTypingBatch } = await import('./telegram-utils');

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -257,7 +257,7 @@ export function initializeClientsCommand(bot: any) {
 		return;
 	}
 
-	const gptResponse = await getYandexGPTResponse(gptMessages, 'summary', businessConnectionId || '');
+	const gptResponse = await getYandexGPTResponse(gptMessages, 'summary', businessConnectionId || '', clientId);
 	
     if (gptResponse && gptResponse.text && client) {
       let message = `*Информация о клиенте ${getClientDisplayName(client)}*\n\n`+`${gptResponse.text}`;


### PR DESCRIPTION
- Add new budget table in database to track token usage
- Implement budget logging in getYandexGPTResponse function
- Pass chatId parameter to track usage per chat session