### PR TITLE
fix: remove errors if rieltor stops bot

### DIFF
--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -30,23 +30,34 @@ export async function handleBatchMessages(
 			const textToReply = gptResponse.text;
 			const delay = textToReply.length * 200;
 			await imitateTypingBatch(bot, chatId, 0, delay);
-			
-			// Отправляем сообщение через business connection если он указан
-			const sentMessage = businessConnectionId 
-				? await bot.api.sendMessage(chatId, gptResponse.text, { business_connection_id: businessConnectionId })
-				: await bot.api.sendMessage(chatId, gptResponse.text);
 
-			await addChatMessage(
-				chatId,
-				sentMessage.message_id,
-				businessConnectionId,
-				gptResponse.text,
-				'bot'
-			);
+			try {
+				// Пытаемся отправить сообщение через business connection если он указан
+				const sentMessage = businessConnectionId 
+					? await bot.api.sendMessage(chatId, gptResponse.text, { business_connection_id: businessConnectionId })
+					: await bot.api.sendMessage(chatId, gptResponse.text);
 
-			await markMessagesAsAnswered(chatId, businessConnectionId, messageIds);
+				await addChatMessage(
+					chatId,
+					sentMessage.message_id,
+					businessConnectionId,
+					gptResponse.text,
+					'bot'
+				);
+
+				await markMessagesAsAnswered(chatId, businessConnectionId, messageIds);
+
+			} catch (e: any) {
+				// если риелтор отключил бот после получения сообщения от клиента и ответ невозможно доставить
+				if (e.description?.includes('BUSINESS_PEER_INVALID')) {
+					await markMessagesAsAnswered(chatId, businessConnectionId, messageIds);
+					console.warn('Ответ не доставлен из-за того, что пользователь отключил бот, BUSINESS_PEER_INVALID');
+				} else {
+					throw e;
+				}
+			}
 		}
 	} catch (error) {
-		console.error('Batch processing error:', JSON.stringify(error));
+		console.error('Ошибка при ответе на сообщение от клиента:', JSON.stringify(error));
 	}
 }


### PR DESCRIPTION
Починила поведение сервиса при отключении бота.

**Проблема**
Клиент отправляет риелтору сообщение, через несколько секунд риелтор отключает бота. Так как сообщение клиента успело попасть в бд, функция, которая триггерится каждую минуту попытается отправить сообщение клиенту, но не сможет, так как бот отключен. 

**Решение**
Обернула в try/catch попытку отправить сообщение клиенту. Если не получилось, т.е. есть BUSINESS_PEER_INVALID, то мы просто помечаем сообщение клиента, как отвеченное и выводим в консоль информацию об этом. Если ошибка другая, то пробрасываем дальше.

В результате будет в логах вот так, а на такое сообщение клиента бот отвечать уже не будет отдельно (просто будет иметь ввиду, при получении истории последних сообщений, не знаю, ок ли это)

<img width="1170" alt="Снимок экрана 2025-07-01 в 13 28 18" src="https://github.com/user-attachments/assets/5eb83cde-7bed-4a1e-a886-85904c5c40c1" />
