### PR TITLE
chore: no demo and activate with empty profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy-test": "env -u YC_FUNCTION_NAME -u BOT_TOKEN -u YDB_DATABASE -u YC_ENTRYPOINT dotenv -e .envtest -- bash -c 'npm run _deploy-common'",
     "deploy-answering": "env -u YC_FUNCTION_NAME -u BOT_TOKEN -u YDB_DATABASE -u YC_ENTRYPOINT dotenv -e .envanswering -- bash -c 'npm run _deploy-common'",
     "deploy-answering-test": "env -u YC_FUNCTION_NAME -u BOT_TOKEN -u YDB_DATABASE -u YC_ENTRYPOINT dotenv -e .envansweringtest -- bash -c 'npm run _deploy-common'",
+    "deploy-settings": "env -u YC_FUNCTION_NAME -u BOT_TOKEN -u YDB_DATABASE -u YC_ENTRYPOINT dotenv -e .envsettings -- bash -c 'npm run _deploy-common'",
     "deploy-settings-test": "env -u YC_FUNCTION_NAME -u BOT_TOKEN -u YDB_DATABASE -u YC_ENTRYPOINT dotenv -e .envsettingstest -- bash -c 'npm run _deploy-common'",
     "clear-cache": "echo \"Для очистки кеша выполните: unset YC_FUNCTION_NAME BOT_TOKEN YDB_DATABASE YC_ENTRYPOINT\""
   },

--- a/src/activate-command.ts
+++ b/src/activate-command.ts
@@ -1,6 +1,6 @@
 import { Bot, CommandContext, Context } from 'grammy';
 import { setMode } from './ydb';
-import { formatMarkdownV2Text, escapeMarkdownV2 } from './telegram-utils';
+import { formatMarkdownV2Text, escapeMarkdownV2, isUserProfileComplete } from './telegram-utils';
 
 /**
  * Создает безопасное сообщение для MarkdownV2 с инструкцией активации
@@ -25,6 +25,11 @@ export function initializeActivateCommand(bot: Bot) {
         const userId = ctx.from?.id;
         if (!userId) {
             await ctx.reply('Не удалось определить ваш ID.');
+            return;
+        }
+
+        if (!(await isUserProfileComplete(userId))) {
+            await ctx.api.sendMessage(userId, 'Сначала полностью заполните профиль, пройдя опросник с помощью команды /quiz');
             return;
         }
 

--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -75,6 +75,8 @@ export async function handleBatchMessages(
 					throw e;
 				}
 			}
+		} else {
+			console.error('[handleBatchMessages] Ошибка от gpt, сообщения НЕ помечаем как отвеченные:', gptResponse?.text);
 		}
 	} catch (error) {
 		console.error('Ошибка при ответе на сообщение от клиента:', JSON.stringify(error));

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { initializeStartCommand } from './start-command';
 import { bot } from './bot-instance';
 import {processAllUnansweredChats} from "./process-unanswered-messages";
 import { handleVoiceMessage } from './voice-handler';
-import { TelegramVoice } from './telegram-utils';
+import { TelegramVoice, isUserProfileComplete } from './telegram-utils';
 import { Context } from 'grammy';
 import { initializeActivateCommand } from './activate-command';
 
@@ -95,6 +95,10 @@ bot.command('demo', async (ctx) => {
       await setMode(userId, 'none');
       await ctx.reply('Режим демонстрации выключен.');
     } else {
+        if (!(await isUserProfileComplete(userId))) {
+            await ctx.api.sendMessage(userId, 'Сначала полностью заполните профиль, пройдя опросник с помощью команды /quiz');
+            return;
+        }
       await setMode(userId, 'demo');
       await ctx.reply(`Режим демонстрации включен. Теперь вы можете пообщаться со своим аватаром отсюда.`);
     }

--- a/src/process-unanswered-messages.ts
+++ b/src/process-unanswered-messages.ts
@@ -9,7 +9,6 @@ export async function processAllUnansweredChats() {
       if (messages.length > 0) {
         const messageIds = messages.map(m => m.messageId);
         await handleBatchMessages(chatId, business_connection_id, messageIds);
-        await markMessagesAsAnswered(chatId, business_connection_id, messageIds);
       }
     })
   );


### PR DESCRIPTION
Если профиль не заполнен до конца, то невозможно активировать бизнес-аккаунт и включить режим демонстрации. Профиль должен быть заполнен полностью, иначе при клике на такие команды появится сообщение:
_"Сначала полностью заполните профиль, пройдя опросник с помощью команды /quiz"_

Кроме того, исправила баг, когда даже при ошибках от гпт сообщения помечались отвеченными. Теперь этого не происходит.