### PR TITLE
chore: add stickers to chat-handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,13 @@
         "fetch-retry-proxy": "^1.0.0",
         "grammy": "^1.36.3",
         "https-proxy-agent": "^7.0.6",
+        "lodash": "^4.17.21",
         "node-fetch": "^3.3.2",
         "socks-proxy-agent": "^8.0.5",
         "ydb-sdk": "^5.11.0"
       },
       "devDependencies": {
+        "@types/lodash": "^4.17.20",
         "@types/node": "^24.0.0",
         "dotenv-cli": "^8.0.0",
         "typescript": "^5.8.3"
@@ -144,6 +146,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.0.0",
@@ -1049,7 +1058,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
     "fetch-retry-proxy": "^1.0.0",
     "grammy": "^1.36.3",
     "https-proxy-agent": "^7.0.6",
+    "lodash": "^4.17.21",
     "node-fetch": "^3.3.2",
     "socks-proxy-agent": "^8.0.5",
     "ydb-sdk": "^5.11.0"
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.20",
     "@types/node": "^24.0.0",
     "dotenv-cli": "^8.0.0",
     "typescript": "^5.8.3"

--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -21,7 +21,7 @@ export async function chatHandler(
 	const businessConnectionId = ctx.businessConnectionId || '';
 	const messageId = message?.message_id || 0;
 	const repliedText = message?.reply_to_message?.text || '';
-	const text = message?.text || '';
+	const text = message?.text || message?.sticker?.emoji || '';
 
 	if (quickMode) {
 		await addChatMessage(chatId, messageId, businessConnectionId, text, who, repliedText, true);

--- a/src/process-unanswered-messages.ts
+++ b/src/process-unanswered-messages.ts
@@ -1,15 +1,11 @@
 import { getAllUnansweredMessages } from './ydb';
 import { handleBatchMessages } from './chat-handler';
+import groupBy from 'lodash/groupBy';
 
 export async function processAllUnansweredChats() {
   const allUnanswered = await getAllUnansweredMessages();
 
-  const grouped: Record<string, typeof allUnanswered> = {};
-  for (const msg of allUnanswered) {
-    const key = `${msg.chatId}:${msg.business_connection_id}`;
-    if (!grouped[key]) grouped[key] = [];
-    grouped[key].push(msg);
-  }
+  const grouped = groupBy(allUnanswered, msg => `${msg.chatId}:${msg.business_connection_id}`);
 
   for (const key in grouped) {
     const [chatId, business_connection_id] = key.split(':');


### PR DESCRIPTION
добавила распознавание стикеров (эмоджи и так передаются не как пустое сообщение). Чтобы бот реагировал на них особенно, можно в уточнениях к промпту добавлять что-то типа такого (пример конечно преувеличенный):

```
Если пользователь отправляет только эмодзи, реагируй на них по смыслу:
  - Позитивные эмодзи (😊, 😃, 👍, 🎉, 😍 и т.п.) — отвечай: «О, круто!» или «Рад за тебя!»
  - Негативные эмодзи (😢, 😞, 😡, 👎 и т.п.) — отвечай: «Как жаль» или «Сочувствую».
  - Если смысл эмодзи не ясен — просто поблагодари за эмодзи.
```
  
Еще группировку неотвеченных сообщений сделала через lodash

Распознавание картинок надо делать отдельно, это более сложная задача (gemini еще может распознавать, для yandex gpt надо отдельный сервис использовать, например yandex vision)

