### PR TITLE
chore: add media messages handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,12 +108,13 @@ async function chat(ctx: Context, who: Who, message: Message) {
   const userId = await getUserIdByBusinessConnectionId(ctx?.businessConnectionId||'')||0;
   const mode = await getMode(message.chat.id);
 
+  // TODO: реализовать распознавание файлов
   if (message.photo || message.animation || message.document) {
       try {
           const id = mode === 'demo' ? message.chat.id : userId;
           await handleMediaMessage(ctx, message, id);
       } catch (e) {
-          console.error('Ошибка при отправке уведомления о медиа:', e);
+          console.error('[chat]: Ошибка при отправке уведомления о медиа:', e);
       }
       return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { Api, Bot, Context, RawApi } from 'grammy';
 import { initializeActivateCommand } from './activate-command';
 import { Message } from 'grammy/types';
 import { getUserIdByBusinessConnectionId } from './users';
+import { handleMediaMessage } from './media-handler';
 
 // Глобальная переменная для отслеживания инициализации
 let botInitialized = false;
@@ -104,6 +105,18 @@ bot.command('demo', async (ctx) => {
 
 async function chat(ctx: Context, who: Who, message: Message) {
   console.log('chat.message:', JSON.stringify(message));
+  const userId = await getUserIdByBusinessConnectionId(ctx?.businessConnectionId||'')||0;
+  const mode = await getMode(message.chat.id);
+
+  if (message.photo || message.animation || message.document) {
+      try {
+          const id = mode === 'demo' ? message.chat.id : userId;
+          await handleMediaMessage(ctx, message, id);
+      } catch (e) {
+          console.error('Ошибка при отправке уведомления о медиа:', e);
+      }
+      return;
+  }
   
   if (message.voice) {
     const { file_id, duration, mime_type, file_size } = message.voice as TelegramVoice;

--- a/src/media-handler.ts
+++ b/src/media-handler.ts
@@ -1,0 +1,14 @@
+import {Context} from "grammy";
+import {Message} from "grammy/out/types";
+
+export async function handleMediaMessage (ctx: Context, message: Message, userId: number) {
+    const clientUsername = message.chat?.username;
+    const clientId = message.chat?.id;
+    let clientLink = clientUsername
+        ? `https://t.me/${clientUsername}`
+        : `tg://user?id=${clientId}`;
+
+    const notifyText = `Клиент прислал файл, который бот пока не умеет их обрабатывать, поэтому нужно ответить вручную. [Открыть чат с клиентом](${clientLink})`;
+
+    await ctx.api.sendMessage(userId, notifyText, { parse_mode: 'Markdown' });
+}

--- a/src/media-handler.ts
+++ b/src/media-handler.ts
@@ -8,7 +8,7 @@ export async function handleMediaMessage (ctx: Context, message: Message, userId
         ? `https://t.me/${clientUsername}`
         : `tg://user?id=${clientId}`;
 
-    const notifyText = `Клиент прислал файл, который бот пока не умеет их обрабатывать, поэтому нужно ответить вручную. [Открыть чат с клиентом](${clientLink})`;
+    const notifyText = `Клиент прислал файл, который бот пока не умеет обрабатывать, поэтому нужно ответить вручную. [Открыть чат с клиентом](${clientLink})`;
 
     await ctx.api.sendMessage(userId, notifyText, { parse_mode: 'Markdown' });
 }


### PR DESCRIPTION
Так как мы пока не умеем обрабатывать всякие файлы, которые отправляет клиент, делаем так:
при получении таких файлов не записываем в базу, а отправляем риелтору в админку сообщение о том, что надо бы вручную ответить + для удобства ссылку на чат
<img width="411" height="224" alt="Снимок экрана 2025-07-14 в 16 00 11" src="https://github.com/user-attachments/assets/fa536ce5-abe9-4b08-938e-796b5156a822" />
В демо-режиме тоже такая штука будет работать, можно потестировать в моем боте "Настин бот". Пока такие сообщения приходят при отправке картинок, гифок и пдф файлов

